### PR TITLE
feat: 태그 글자 제한 및 링크 텍스트에 속성 추가

### DIFF
--- a/src/app/(AfterLogin)/community/_component/PostDetail.tsx
+++ b/src/app/(AfterLogin)/community/_component/PostDetail.tsx
@@ -201,12 +201,10 @@ export default function PostDetail({ post }: { post: Post }) {
     <div className="px-6 pt-4 pb-2 mb-5 border border-gray-300 rounded-md">
       <span className="text-2xl font-bold">{post.postTitle}</span>
       <hr className="mt-2" />
-      <div className="flex-col">
-        <div
-          className="my-5 pb-8 whitespace-pre-line"
-          dangerouslySetInnerHTML={{ __html: convertedContent }}
-        />
-      </div>
+      <div
+        className="my-5 pb-8 whitespace-pre-line break-words"
+        dangerouslySetInnerHTML={{ __html: convertedContent }}
+      />
       {post.tag.map((tag, index) => (
         <Badge
           key={index}

--- a/src/app/(AfterLogin)/community/_component/PostUpdater.tsx
+++ b/src/app/(AfterLogin)/community/_component/PostUpdater.tsx
@@ -33,6 +33,7 @@ export default function PostUpdater({
   const [errors, setErrors] = useState({ title: false, content: false, tags: false });
   const [isFocused, setIsFocused] = useState(false);
   const [isLinux, setIsLinux] = useState(false);
+  const [tagWarning, setTagWarning] = useState("");
 
   const queryClient = useQueryClient();
   const { openDialogWithBack } = useModal();
@@ -107,7 +108,13 @@ export default function PostUpdater({
   };
 
   const handleNewTagChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNewTag(e.target.value);
+    const tagValue = e.target.value;
+    if (tagValue.length > 10) {
+      setTagWarning("태그는 최대 10자까지 입력 가능합니다!");
+    } else {
+      setTagWarning("");
+      setNewTag(tagValue);
+    }
   };
 
   const handleNewTagKeyDown = (e: React.KeyboardEvent) => {
@@ -121,6 +128,7 @@ export default function PostUpdater({
       e.preventDefault();
       setTags([...tags, newTag.trim()]);
       setNewTag("");
+      setTagWarning("");
       if (errors.tags) setErrors((prev) => ({ ...prev, tags: false }));
     } else if (isLinux && targetKey.value.at(-1) === " ") {
       if (e.nativeEvent.isComposing) return;
@@ -132,6 +140,7 @@ export default function PostUpdater({
       if (trimmedTag !== "") {
         setTags([...tags, trimmedTag]);
         setNewTag("");
+        setTagWarning("");
         if (errors.tags) setErrors((prev) => ({ ...prev, tags: false }));
       }
     }
@@ -180,6 +189,7 @@ export default function PostUpdater({
             placeholder="태그를 입력하세요"
             className="w-2/3 border-none focus:outline-none"
           />
+          {tagWarning && <p className="text-sm text-red-500 mt-1">{tagWarning}</p>}
           {isFocused && (
             <div className="absolute bg-gray-700 text-slate-100 text-xs p-2.5 mt-2 z-10 whitespace-pre-line">
               {isLinux


### PR DESCRIPTION
- 태그 입력 글자 수 제한을 설정하고, 10자 이상 입력 시 최대 10자까지 입력할 수 있다는 안내 문구를 추가했습니다.
- 게시글 내부 링크 텍스트가 너무 길어서 화면을 벗어나는 현상을 방지하기 위해 break-words 속성을 추가했습니다.